### PR TITLE
update cats to 0.4.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ReleaseTransformations._
 
 val bijectionVersion = "0.8.1"
-val catsVersion = "0.4.0-SNAPSHOT"
+val catsVersion = "0.4.0"
 val utilVersion = "6.30.0"
 val finagleVersion = "6.31.0"
 
@@ -33,7 +33,7 @@ lazy val baseSettings = Seq(
   ),
   scalacOptions in (Compile, console) := compilerOptions,
   libraryDependencies ++= Seq(
-    "org.spire-math" %% "cats-core" % catsVersion,
+    "org.typelevel" %% "cats-core" % catsVersion,
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
   resolvers += Resolver.sonatypeRepo("snapshots"),
@@ -70,7 +70,7 @@ lazy val tests = project
       "com.twitter" %% "util-core" % utilVersion,
       "org.scalacheck" %% "scalacheck" % "1.12.5",
       "org.scalatest" %% "scalatest" % "3.0.0-M9",
-      "org.spire-math" %% "cats-laws" % catsVersion,
+      "org.typelevel" %% "cats-laws" % catsVersion,
       "org.typelevel" %% "discipline" % "0.4"
     ),
     coverageExcludedPackages := "io\\.catbird\\.tests\\..*"

--- a/finagle/src/main/scala/io/catbird/finagle/service.scala
+++ b/finagle/src/main/scala/io/catbird/finagle/service.scala
@@ -26,7 +26,7 @@ trait ServiceInstances {
 
 trait ServiceConversions {
   implicit def serviceToKleisli[I, O]: Injection[Service[I, O], Kleisli[Future, I, O]] =
-    Injection.build[Service[I, O], Kleisli[Future, I, O]](Kleisli.function) {
+    Injection.build[Service[I, O], Kleisli[Future, I, O]](Kleisli(_)) {
       case Kleisli(service: Service[I, O]) => Success(service)
       case other => InversionFailure.failedAttempt(other)
     }

--- a/util/src/main/scala/io/catbird/util/future.scala
+++ b/util/src/main/scala/io/catbird/util/future.scala
@@ -9,7 +9,7 @@ trait FutureInstances extends FutureInstances1 {
       def pure[A](x: A): Future[A] = Future.value(x)
       def flatMap[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)
       override final def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa.map(f)
-      override final def ap[A, B](fa: Future[A])(f: Future[A => B]): Future[B] = fa.join(f).map {
+      override final def ap[A, B](f: Future[A => B])(fa: Future[A]): Future[B] = fa.join(f).map {
         case (a, ab) => ab(a)
       }
       override final def product[A, B](fa: Future[A], fb: Future[B]): Future[(A, B)] = fa.join(fb)


### PR DESCRIPTION
Having found this a valuable library and ready to speed my compile up by moving to 0.4.0 release of cats I took the quick step of doing that for catbird. Beyond the version bump there are a couple of very minor fixes. First replace Kleisli.function with apply. Secondly change order of parameters to ap in futureInstance. 