### PR TITLE
Rename implicit future instances to avoid shadowing by cats versions

### DIFF
--- a/finagle/src/main/scala/io/catbird/finagle/service.scala
+++ b/finagle/src/main/scala/io/catbird/finagle/service.scala
@@ -2,13 +2,13 @@ package io.catbird.finagle
 
 import cats.arrow.Category
 import cats.functor.Profunctor
-import io.catbird.util.futureInstance
+import io.catbird.util.twitterFutureInstance
 import com.twitter.finagle.Service
 
 trait ServiceInstances {
   implicit val serviceInstance: Category[Service] with Profunctor[Service] =
     new Category[Service] with Profunctor[Service] {
-      final def id[A]: Service[A, A] = Service.mk(futureInstance.pure)
+      final def id[A]: Service[A, A] = Service.mk(twitterFutureInstance.pure)
 
       final def compose[A, B, C](f: Service[B, C], g: Service[A, B]): Service[A, C] =
         Service.mk(a => g(a).flatMap(f))

--- a/tests/src/main/scala/io/catbird/tests/finagle/arbitrary.scala
+++ b/tests/src/main/scala/io/catbird/tests/finagle/arbitrary.scala
@@ -1,10 +1,10 @@
 package io.catbird.tests.finagle
 
 import com.twitter.finagle.Service
-import io.catbird.util.futureInstance
+import io.catbird.util.twitterFutureInstance
 import org.scalacheck.Arbitrary
 
 trait ArbitraryInstances {
   implicit def serviceArbitrary[I, O](implicit arbF: Arbitrary[I => O]): Arbitrary[Service[I, O]] =
-    Arbitrary(arbF.arbitrary.map(f => Service.mk(i => futureInstance.pure(f(i)))))
+    Arbitrary(arbF.arbitrary.map(f => Service.mk(i => twitterFutureInstance.pure(f(i)))))
 }

--- a/tests/src/test/scala/io/catbird/util/future.scala
+++ b/tests/src/test/scala/io/catbird/util/future.scala
@@ -25,6 +25,6 @@ class FutureSuite extends FunSuite with Discipline with FutureInstances with Arb
   checkAll("Future[Int]", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
   checkAll("Future[Int]", ComonadTests[Future].comonad[Int, Int, Int])
   checkAll("Future[Int]", FunctorTests[Future](comonad).functor[Int, Int, Int])
-  checkAll("Future[Int]", GroupLaws[Future[Int]].semigroup(futureSemigroup[Int]))
+  checkAll("Future[Int]", GroupLaws[Future[Int]].semigroup(twitterFutureSemigroup[Int]))
   checkAll("Future[Int]", GroupLaws[Future[Int]].monoid)
 }

--- a/util/src/main/scala/io/catbird/util/future.scala
+++ b/util/src/main/scala/io/catbird/util/future.scala
@@ -4,7 +4,7 @@ import cats.{ CoflatMap, Comonad, Eq, Eval, MonadError, Monoid, Semigroup }
 import com.twitter.util.{ Await, Duration, Future, Try }
 
 trait FutureInstances extends FutureInstances1 {
-  implicit final val futureInstance: MonadError[Future, Throwable] with CoflatMap[Future] =
+  implicit final val twitterFutureInstance: MonadError[Future, Throwable] with CoflatMap[Future] =
     new FutureCoflatMap with MonadError[Future, Throwable] {
       final def pure[A](x: A): Future[A] = Future.value(x)
       override final def pureEval[A](x: Eval[A]): Future[A] = Future(x.value)
@@ -22,7 +22,7 @@ trait FutureInstances extends FutureInstances1 {
       final def raiseError[A](e: Throwable): Future[A] = Future.exception(e)
     }
 
-  implicit final def futureSemigroup[A](implicit A: Semigroup[A]): Semigroup[Future[A]] =
+  implicit final def twitterFutureSemigroup[A](implicit A: Semigroup[A]): Semigroup[Future[A]] =
     new FutureSemigroup[A]
 
   final def futureEq[A](atMost: Duration)(implicit A: Eq[A]): Eq[Future[A]] = new Eq[Future[A]] {
@@ -45,7 +45,7 @@ private[util] trait FutureInstances1 {
       def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa.map(f)
     }
 
-  implicit final def futureMonoid[A](implicit A: Monoid[A]): Monoid[Future[A]] =
+  implicit final def twitterFutureMonoid[A](implicit A: Monoid[A]): Monoid[Future[A]] =
     new FutureSemigroup[A] with Monoid[Future[A]] {
       def empty: Future[A] = Future.value(A.empty)
     }


### PR DESCRIPTION
```
futureInstance  => twitterFutureInstance
futureSemigroup => twitterFututreSemigroup
futureMonoid    => twitterFutureMonoid
```