### PR TITLE
Arrows instances

### DIFF
--- a/arrows/src/main/scala/io/catbird/arrows/TaskInstances.scala
+++ b/arrows/src/main/scala/io/catbird/arrows/TaskInstances.scala
@@ -1,0 +1,80 @@
+package io.catbird.arrows
+
+import _root_.arrows.twitter.Task
+import cats.{ CoflatMap, Comonad, Eq, MonadError, Monoid, Semigroup }
+import com.twitter.util.{ Await, Duration, Return, Throw, Try }
+import java.lang.Throwable
+import scala.Boolean
+import scala.util.{ Either, Left, Right }
+
+trait TaskInstances extends TaskInstances1 {
+  implicit final val arrowsTaskInstance: MonadError[Task, Throwable] with CoflatMap[Task] =
+    new TaskCoflatMap with MonadError[Task, Throwable] {
+      final def pure[A](x: A): Task[A] = Task.value(x)
+      final def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
+      override final def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+      override final def ap[A, B](f: Task[A => B])(fa: Task[A]): Task[B] = Task.join(f, fa).map {
+        case (ab, a) => ab(a)
+      }
+      override final def product[A, B](fa: Task[A], fb: Task[B]): Task[(A, B)] = Task.join(fa, fb)
+
+      final def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
+        fa.rescue {
+          case e => f(e)
+        }
+      final def raiseError[A](e: Throwable): Task[A] = Task.exception(e)
+
+      final def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] = f(a).flatMap {
+        case Right(b) => pure(b)
+        case Left(nextA) => tailRecM(nextA)(f)
+      }
+    }
+
+  implicit final def arrowsTaskSemigroup[A](implicit A: Semigroup[A]): Semigroup[Task[A]] =
+    new TaskSemigroup[A]
+
+  final def taskEq[A](atMost: Duration)(implicit A: Eq[A]): Eq[Task[A]] = new Eq[Task[A]] {
+    final def eqv(x: Task[A], y: Task[A]): Boolean = Await.result(
+      Task.join(x, y).map {
+        case (xa, ya) => A.eqv(xa, ya)
+      }.run(()),
+      atMost
+    )
+  }
+
+  final def taskEqWithFailure[A](atMost: Duration)(implicit A: Eq[A], T: Eq[Throwable]): Eq[Task[A]] = {
+    val tryEq = new Eq[Try[A]] {
+      def eqv(x: Try[A], y: Try[A]): Boolean = (x, y) match {
+        case (Throw(xError), Throw(yError)) => T.eqv(xError, yError)
+        case (Return(xValue), Return(yValue)) => A.eqv(xValue, yValue)
+        case _ => false
+      }
+    }
+
+    Eq.by[Task[A], Task[Try[A]]](_.liftToTry)(taskEq[Try[A]](atMost)(tryEq))
+  }
+}
+
+private[arrows] trait TaskInstances1 {
+  final def taskComonad(atMost: Duration): Comonad[Task] =
+    new TaskCoflatMap with Comonad[Task] {
+      final def extract[A](x: Task[A]): A = Await.result(x.run(()), atMost)
+      final def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+    }
+
+  implicit final def arrowsTaskMonoid[A](implicit A: Monoid[A]): Monoid[Task[A]] =
+    new TaskSemigroup[A] with Monoid[Task[A]] {
+      final def empty: Task[A] = Task.value(A.empty)
+    }
+}
+
+private[arrows] sealed abstract class TaskCoflatMap extends CoflatMap[Task] {
+  final def coflatMap[A, B](fa: Task[A])(f: Task[A] => B): Task[B] = Task(f(fa))
+}
+
+private[arrows] sealed class TaskSemigroup[A](implicit A: Semigroup[A])
+  extends Semigroup[Task[A]] {
+    final def combine(fx: Task[A], fy: Task[A]): Task[A] = Task.join(fx, fy).map {
+      case (x, y) => A.combine(x, y)
+    }
+  }

--- a/arrows/src/main/scala/io/catbird/arrows/package.scala
+++ b/arrows/src/main/scala/io/catbird/arrows/package.scala
@@ -1,0 +1,3 @@
+package io.catbird
+
+package object arrows extends TaskInstances

--- a/arrows/src/test/scala/io/catbird/arrows/TaskSuite.scala
+++ b/arrows/src/test/scala/io/catbird/arrows/TaskSuite.scala
@@ -1,0 +1,45 @@
+package io.catbird.arrows
+
+import _root_.arrows.twitter.Task
+import cats.Comonad
+import cats.data.EitherT
+import cats.instances.either._
+import cats.instances.int._
+import cats.instances.tuple._
+import cats.instances.unit._
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.MonoidTests
+import cats.laws.discipline._
+import cats.laws.discipline.arbitrary._
+import com.twitter.conversions.time._
+import io.catbird.util.{ ArbitraryInstances, EqInstances }
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalatest.FunSuite
+import org.typelevel.discipline.scalatest.Discipline
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+
+class RerunnableSuite extends FunSuite with Discipline with ArbitraryInstances with EqInstances {
+  implicit def taskEq[A](implicit A: Eq[A]): Eq[Task[A]] =
+    io.catbird.arrows.taskEqWithFailure[A](1.second)
+  implicit val taskComonad: Comonad[Task] = io.catbird.arrows.taskComonad(1.second)
+
+  implicit def taskArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[Task[A]] =
+    Arbitrary(A.arbitrary.map(Task.value))
+
+  implicit def taskCogen[A](implicit A: Cogen[A]): Cogen[Task[A]] =
+    A.contramap(taskComonad.extract)
+
+  /**
+   * I'm not sure why this can't be resolved implicitly (maybe the aliasness of
+   * `Task`?).
+   */
+  implicit val eitherTEq: Eq[EitherT[Task, Throwable, Int]] =
+    EitherT.catsDataEqForEitherT[Task, Throwable, Int]
+
+  implicit val taskIsomorphisms: Isomorphisms[Task] = Isomorphisms.invariant[Task](taskComonad)
+
+  checkAll("Task[Int]", MonadErrorTests[Task, Throwable].monadError[Int, Int, Int])
+  checkAll("Task[Int]", ComonadTests[Task].comonad[Int, Int, Int])
+  checkAll("Task[Int]", FunctorTests[Task](taskComonad).functor[Int, Int, Int])
+  checkAll("Task[Int]", MonoidTests[Task[Int]].monoid)
+}

--- a/benchmark/src/test/scala/io/catbird/benchmark/RerunnableBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/catbird/benchmark/RerunnableBenchmarkSpec.scala
@@ -21,7 +21,15 @@ class RerunnableBenchmarkSpec extends FlatSpec with BeforeAndAfter {
     assert(benchmark.sumIntsR === sum)
   }
 
+  it should "correctly calculate the sum using tasks" in {
+    assert(benchmark.sumIntsT === sum)
+  }
+
   it should "correctly calculate the sum using rerunnables and future pools" in {
     assert(benchmark.sumIntsPR === sum)
+  }
+
+  it should "correctly calculate the sum using tasks and future pools" in {
+    assert(benchmark.sumIntsPT === sum)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ val catsVersion = "1.1.0"
 val catsEffectVersion = "0.10.1"
 val utilVersion = "18.7.0"
 val finagleVersion = "18.7.0"
+val arrowsVersion = "0.1.21"
 
 organization in ThisBuild := "io.catbird"
 
@@ -76,6 +77,16 @@ lazy val util = project
       _.filterNot(Set("-Yno-imports", "-Yno-predef"))
     }
   )
+
+lazy val arrows = project
+  .settings(moduleName := "catbird-arrows")
+  .settings(allSettings)
+  .settings(
+    libraryDependencies += "io.trane" %% "arrows-twitter" % arrowsVersion,
+    scalacOptions in Test ~= {
+      _.filterNot(Set("-Yno-imports", "-Yno-predef"))
+    }
+  ).dependsOn(util % "test->test")
 
 lazy val effect = project
   .settings(moduleName := "catbird-effect")

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,7 @@ lazy val benchmark = project
     }
   )
   .enablePlugins(JmhPlugin)
-  .dependsOn(util)
+  .dependsOn(util, arrows)
 
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,


### PR DESCRIPTION
This is just a sketch—still needs cats-effect instances, etc. From a quick benchmark run on my laptop (I don't have access to my desktop at the moment):

```
Benchmark                       Mode  Cnt    Score    Error  Units
RerunnableBenchmark.sumIntsF   thrpt    5   51.840 ±  7.956  ops/s
RerunnableBenchmark.sumIntsR   thrpt    5   77.285 ±  9.848  ops/s
RerunnableBenchmark.sumIntsT   thrpt    5  150.470 ± 51.710  ops/s
```

Where `F` is `Future`, `R` is `Rerunnable`, and `T` is `Task`. So it's looking pretty good compared to `Rerunnable`, at least for this extremely simple benchmark.