### PR TITLE
update twitter ecosystem version(s)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import ReleaseTransformations._
 
-val catsVersion = "1.3.1"
+val catsVersion = "1.4.0"
 val catsEffectVersion = "1.0.0"
-val utilVersion = "18.9.0"
-val finagleVersion = "18.9.0"
+val utilVersion = "18.9.1"
+val finagleVersion = "18.9.1"
 
 organization in ThisBuild := "io.catbird"
 


### PR DESCRIPTION
due to the constant breakage we've had to go to a strict conflict manager for builds. this fixes my problem with the twitter versions breaking things, and as a side effect I updated the cats version.