### PR TITLE
bumps finagle to 18.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import ReleaseTransformations._
 
 val catsVersion = "1.4.0"
 val catsEffectVersion = "1.0.0"
-val utilVersion = "18.9.1"
-val finagleVersion = "18.9.1"
+val utilVersion = "18.10.0"
+val finagleVersion = "18.10.0"
 
 organization in ThisBuild := "io.catbird"
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "18.9.2-SNAPSHOT"
+version in ThisBuild := "18.10.0-SNAPSHOT"


### PR DESCRIPTION
Bumps finagle to `18.10.0` to match version in upcoming `finagle/finch 0.25.0` release

https://github.com/finagle/finch/pull/1007 