### PR TITLE
[WIP] Add cats.Parallel instance for Future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
   - 2.12.8
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sbt_args: -J-Xmx8192M
 

--- a/util/src/main/scala/io/catbird/util/internal/Newtype1.scala
+++ b/util/src/main/scala/io/catbird/util/internal/Newtype1.scala
@@ -1,0 +1,24 @@
+package io.catbird.util.internal
+
+/** INTERNAL API — Newtype encoding for types with one type parameter.
+ *
+ * The `Newtype1` abstract class indirection is needed for Scala 2.10,
+ * otherwise we could just define these types straight on the
+ * companion object. In Scala 2.10 definining these types
+ * straight on the companion object yields an error like:
+ * ''"only classes can have declared but undefined members"''.
+ *
+ * Inspired by
+ * [[https://github.com/alexknvl/newtypes alexknvl/newtypes]].
+ */
+private[util] abstract class Newtype1[F[_]] { self =>
+  type Base
+  trait Tag extends scala.Any
+  type Type[+A] <: Base with Tag
+
+  def apply[A](fa: F[A]): Type[A] =
+    fa.asInstanceOf[Type[A]]
+
+  def unwrap[A](fa: Type[A]): F[A] =
+    fa.asInstanceOf[F[A]]
+}


### PR DESCRIPTION
Hi,

this is a first attempt at adding a `cats.Parallel` instance (see #90).

Since I'm mostly familiar with `Future` and not `Rerunnable` I implemented it for `Future` first and if that is done I can maybe try to replicate it for `Rerunnable`.

I based the implementation on the implementations for `cats.effect.IO` and `monix.eval.Task` as I know those libraries reasonably well.

I consider this PR WIP as I have some questions:
1. I reused the Newtype concept present in `cats-effect` and `monix`. Both have an Apache2.0 license, so I'm not sure how attribution for this piece of code works. Maybe we can just use it, maybe we need to keep the copyright header, I'm not too familiar how this works, sorry.

2. I put the tests next to the existing ones for `Future`. As `ArbitraryInstances` doesn't have `FuturePar` in scope I couldn't move the instances there. For the moment they are in the `FutureSuite`, but if you don't like this I can put more time into finding a scoping solution to extract it.

3. The elephant in the room is the fact that `ap` and `product` on the normal `Future` instance are already defined in terms of `Future.join`, so they run things in parallel already. This means `traverse` and `parTraverse` as well as `sequence` and `parSequence` will all be parallel. This is in line with the behavior of instances of `scala.concurrent.Future` iirc.
There is the option to change `traverse` to be sequential, but `sequence` cannot be sequential (afaik), so this would be awkward and besides that it'd also be a breaking change. 
I'd argue that `parTraverse` and `parSequence` still have the benefit of explicitly signaling the reader how they will execute, even if they don't necessarily bring new functionality to the table.

Hope this is reasonable. Looking forward to your feedback :)

Cheers
~ Felix