### PR TITLE
19.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import ReleaseTransformations._
 
 val catsVersion = "1.6.1"
 val catsEffectVersion = "1.4.0"
-val utilVersion = "19.6.0"
-val finagleVersion = "19.6.0"
+val utilVersion = "19.8.0"
+val finagleVersion = "19.8.0"
 
 organization in ThisBuild := "io.catbird"
 

--- a/util/src/test/scala/io/catbird/util/asyncstream.scala
+++ b/util/src/test/scala/io/catbird/util/asyncstream.scala
@@ -17,7 +17,7 @@ class AsyncStreamSuite extends FunSuite with Discipline with AsyncStreamInstance
   implicit val eqAsyncStreamAsyncStreamInt: Eq[AsyncStream[AsyncStream[Int]]] = asyncStreamEq(1.second)
   implicit val eqAsyncStreamIntIntInt: Eq[AsyncStream[(Int, Int, Int)]] = asyncStreamEq[(Int, Int, Int)](1.second)
 
-  checkAll("AsyncStream[Int]", MonadTests[AsyncStream].monad[Int, Int, Int])
+  checkAll("AsyncStream[Int]", MonadTests[AsyncStream].stackUnsafeMonad[Int, Int, Int])
   checkAll("AsyncStream[Int]", SemigroupTests[AsyncStream[Int]](asyncStreamSemigroup[Int]).semigroup)
   checkAll("AsyncStream[Int]", MonoidTests[AsyncStream[Int]].monoid)
 


### PR DESCRIPTION
See https://github.com/twitter/util/pull/252 for some context on the `AsyncStream` stack safety issue. Hopefully we'll be able to re-enable it in an upcoming release.