### PR TITLE
Revert "Temporarily remove stack-safety laws checking for AsyncStream"

### DIFF
--- a/util/src/test/scala/io/catbird/util/asyncstream.scala
+++ b/util/src/test/scala/io/catbird/util/asyncstream.scala
@@ -17,7 +17,7 @@ class AsyncStreamSuite extends FunSuite with Discipline with AsyncStreamInstance
   implicit val eqAsyncStreamAsyncStreamInt: Eq[AsyncStream[AsyncStream[Int]]] = asyncStreamEq(1.second)
   implicit val eqAsyncStreamIntIntInt: Eq[AsyncStream[(Int, Int, Int)]] = asyncStreamEq[(Int, Int, Int)](1.second)
 
-  checkAll("AsyncStream[Int]", MonadTests[AsyncStream].stackUnsafeMonad[Int, Int, Int])
+  checkAll("AsyncStream[Int]", MonadTests[AsyncStream].monad[Int, Int, Int])
   checkAll("AsyncStream[Int]", SemigroupTests[AsyncStream[Int]](asyncStreamSemigroup[Int]).semigroup)
   checkAll("AsyncStream[Int]", MonoidTests[AsyncStream[Int]].monoid)
 


### PR DESCRIPTION
This reverts commit 2d1292588942a781b1c0fef54d3be2b6ebe02210 (`flatMap` on `AsyncStream` is [stack-safe again](https://github.com/twitter/util/pull/252)).