### PR TITLE
Add cats.Parallel instance for Rerunnable

### DIFF
--- a/util/src/test/scala/io/catbird/util/RerunnableSuite.scala
+++ b/util/src/test/scala/io/catbird/util/RerunnableSuite.scala
@@ -9,16 +9,26 @@ import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.{ Comonad, Eq }
 import com.twitter.conversions.DurationOps._
+import org.scalacheck.Arbitrary
 import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 class RerunnableSuite extends AnyFunSuite with Discipline with ArbitraryInstances with EqInstances {
   implicit def rerunnableEq[A](implicit A: Eq[A]): Eq[Rerunnable[A]] =
     Rerunnable.rerunnableEqWithFailure[A](1.second)
-  implicit val rerunnableComonad: Comonad[Rerunnable] = Rerunnable.rerunnableComonad(1.second)
+  implicit val rerunnableComonad: Comonad[Rerunnable] =
+    Rerunnable.rerunnableComonad(1.second)
+  implicit val rerunnableParEqInt: Eq[Rerunnable.Par[Int]] =
+    Rerunnable.rerunnableParEqWithFailure(1.second)
+  implicit val rerunnableParEqInt3: Eq[Rerunnable.Par[(Int, Int, Int)]] =
+    Rerunnable.rerunnableParEqWithFailure(1.second)
+  implicit def rerunnableParArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[Rerunnable.Par[A]] =
+    Arbitrary(A.arbitrary.map(value => Rerunnable.Par(Rerunnable.const(value))))
 
   checkAll("Rerunnable[Int]", MonadErrorTests[Rerunnable, Throwable].monadError[Int, Int, Int])
   checkAll("Rerunnable[Int]", ComonadTests[Rerunnable].comonad[Int, Int, Int])
   checkAll("Rerunnable[Int]", FunctorTests[Rerunnable](rerunnableComonad).functor[Int, Int, Int])
   checkAll("Rerunnable[Int]", MonoidTests[Rerunnable[Int]].monoid)
+  checkAll("Rerunnable[Int]", ParallelTests[Rerunnable, Rerunnable.Par].parallel[Int, Int])
+  checkAll("Rerunnable.Par[Int]", CommutativeApplicativeTests[Rerunnable.Par].commutativeApplicative[Int, Int, Int])
 }


### PR DESCRIPTION
This is an attempt to do a similar implementation as with `Future` to complete issue #90.

I want to stress that I've never used `Rerunnable`. My guess is the semantics are similar to `cats.effect.IO` (referentially transparent, lazy, no memoization), but you might want to check if my implementation is what you want from `Rerunnable`.

I've used `Future.join` as a way to run two `Rerunnable` types in parallel. I haven't seen a direct way without `Future`. Please check if this is ok.

As mentioned in the last review the `Newtype1` helper is only needed for 2.10, so I tried to use a more direct encoding this time. Maybe it's possible to do it with even less indirection, but I kept the code close to `Future` and `cats.effect.IO` for the time being.

Cheers
~ Felix