### PR TITLE
Fix threadpool shifting for futureToAsync

### DIFF
--- a/effect/src/main/scala/io/catbird/util/effect/package.scala
+++ b/effect/src/main/scala/io/catbird/util/effect/package.scala
@@ -1,11 +1,16 @@
 package io.catbird.util
 
-import cats.effect.{ Async, IO }
+import cats.effect.{ Async, ContextShift, IO }
 import com.twitter.util.{ Future, Return, Throw }
 import java.lang.Throwable
+
 import scala.util.{ Left, Right }
 
 package object effect extends RerunnableInstances {
+
+  /**
+   * Converts the `Future` to `F` without changing the underlying execution (same thread pool!).
+   */
   def futureToAsync[F[_], A](fa: => Future[A])(implicit F: Async[F]): F[A] = F.async { k =>
     fa.respond {
       case Return(a)  => k(Right[Throwable, A](a))
@@ -13,5 +18,27 @@ package object effect extends RerunnableInstances {
     }
   }
 
-  final def rerunnableToIO[A](fa: Rerunnable[A]): IO[A] = futureToAsync[IO, A](fa.run)
+  /**
+   * The same as `futureToAsync` but doesn't stay on the thread pool of the `Future` and instead shifts execution
+   * back to the one provided by `ContextShift[F]` (which is usually the default one).
+   *
+   * This is likely what you want when you interact with libraries that return a `Future` like `finagle-http` where
+   * the `Future` is running on a thread pool controlled by the library (e.g. the underlying Netty pool).
+   * It also is closer to the behavior of `IO.fromFuture` for Scala futures which also shifts back.
+   */
+  def futureToAsyncAndShift[F[_], A](fa: => Future[A])(implicit F: Async[F], CS: ContextShift[F]): F[A] =
+    F.guarantee(futureToAsync[F, A](fa))(CS.shift)
+
+  /**
+   * Converts the `Rerunnable` to `F` without changing the underlying execution (same thread pool!).
+   */
+  final def rerunnableToIO[A](fa: Rerunnable[A]): IO[A] =
+    futureToAsync[IO, A](fa.run)
+
+  /**
+   * The same as `rerunnableToIO` but doesn't stay on the thread pool of the `Rerunnable` and instead shifts execution
+   * back to the one provided by `ContextShift[F]` (which is usually the default one).
+   */
+  final def rerunnableToIOAndShift[A](fa: Rerunnable[A])(implicit CS: ContextShift[IO]): IO[A] =
+    futureToAsyncAndShift[IO, A](fa.run)
 }

--- a/effect/src/test/scala/io/catbird/util/effect/ContextShiftingSuite.scala
+++ b/effect/src/test/scala/io/catbird/util/effect/ContextShiftingSuite.scala
@@ -1,0 +1,64 @@
+package io.catbird.util.effect
+
+import cats.effect.{ ContextShift, IO }
+import com.twitter.util.{ ExecutorServiceFuturePool, Future, FuturePool }
+import org.scalatest.Outcome
+import org.scalatest.funsuite.FixtureAnyFunSuite
+
+import scala.concurrent.ExecutionContext
+
+class ContextShiftingSuite extends FixtureAnyFunSuite with ThreadPoolNamingSupport {
+
+  protected final class FixtureParam {
+    val ioPoolName = "io-pool"
+    val futurePoolName = "future-pool"
+
+    val ioPool = newNamedThreadPool(ioPoolName)
+
+    val futurePool: ExecutorServiceFuturePool = // threadpool of Future (often managed by a library like finagle-http)
+      FuturePool(newNamedThreadPool(futurePoolName))
+
+    def newIO: IO[String] = IO(currentThreadName())
+
+    def newFuture: Future[String] = futurePool.apply {
+      // Not 100% sure why but this sleep is needed to reproduce the error. There might be an optimization if the
+      // Future is already resolved at some point
+      Thread.sleep(200)
+      currentThreadName()
+    }
+  }
+
+  test("After resolving the Future with futureToAsync stay on the Future threadpool") { f =>
+    implicit val contextShift: ContextShift[IO] = // threadpool of IO (often provided by IOApp)
+      IO.contextShift(ExecutionContext.fromExecutor(f.ioPool))
+
+    val (futurePoolName, ioPoolName) = (for {
+      futurePoolName <- futureToAsync[IO, String](f.newFuture)
+
+      ioPoolName <- f.newIO
+    } yield (futurePoolName, ioPoolName)).start(contextShift).flatMap(_.join).unsafeRunSync()
+
+    assert(futurePoolName == f.futurePoolName)
+    assert(ioPoolName == f.futurePoolName) // Uh oh, this is likely not what the user wants
+  }
+
+  test("After resolving the Future with futureToAsyncAndShift shift back to the threadpool of ContextShift[F]") { f =>
+    implicit val contextShift: ContextShift[IO] = // threadpool of IO (often provided by IOApp)
+      IO.contextShift(ExecutionContext.fromExecutor(f.ioPool))
+
+    // If you'd use `futureToAsync` here instead, this whole thing would sometimes stay on the future-pool
+    val (futurePoolName, ioPoolName) = (for {
+      futurePoolName <- futureToAsyncAndShift[IO, String](f.newFuture)
+
+      ioPoolName <- f.newIO
+    } yield (futurePoolName, ioPoolName))
+      .start(contextShift) // start the computation on the default threadpool...
+      .flatMap(_.join) // ...then block until we have the results
+      .unsafeRunSync()
+
+    assert(futurePoolName == f.futurePoolName)
+    assert(ioPoolName == f.ioPoolName)
+  }
+
+  override protected def withFixture(test: OneArgTest): Outcome = withFixture(test.toNoArgTest(new FixtureParam))
+}

--- a/effect/src/test/scala/io/catbird/util/effect/ThreadPoolNamingSupport.scala
+++ b/effect/src/test/scala/io/catbird/util/effect/ThreadPoolNamingSupport.scala
@@ -1,0 +1,23 @@
+package io.catbird.util.effect
+
+import java.lang.{ Runnable, Thread }
+import java.util.concurrent.{ ExecutorService, Executors, ThreadFactory }
+
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutorService }
+
+trait ThreadPoolNamingSupport {
+
+  def newNamedThreadPool(name: String): ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(
+      Executors.newSingleThreadExecutor(new ThreadFactory {
+        override def newThread(r: Runnable): Thread = {
+          val thread = Executors.defaultThreadFactory().newThread(r)
+          thread.setName(name)
+          thread.setDaemon(true) // Don't block shutdown of JVM
+          thread
+        }
+      })
+    )
+
+  def currentThreadName(): String = Thread.currentThread().getName
+}


### PR DESCRIPTION
**Don't merge this yet, I don't consider this done** 🙂

Hi, I was using `catbird-effect` to wrap `finagle-http` for usage in projects that mainly use `cats.effect.IO` or `monix.eval.Task`.

When I tried a few things locally I noticed in the log output that my logs (wrapped in `IO`) where coming from the `finagle`/`netty` threadpool and not the main one even though the actual http-call was already done.

After some testing and research I came to the conclusion that `io.catbird.util.effect.futureToAsync` is flawed and does only convert `Future` to `IO` but does not shift execution back to the threadpool initially used for `IO`.

I wrote two tests for that (one negative and one positive) so you can easily see the difference and how a solution would look like.

The PR right now adds an additional function `futureToAsyncAndShift` instead of changing the behavior of the existing one. 
However, I strongly think that this is a bad solution as the default should be safe and the current behavior is almost never what users want in practice.

I also looked into how `IO.fromFuture` is implemented for Scala futures and indeed it shifts back to the IO threadpool after the `Future` is resolved. (https://github.com/typelevel/cats-effect/blob/master/core/shared/src/main/scala/cats/effect/IO.scala#L1350-L1355)

Imo this fix would warrant a breaking change (requiring a `ContextShift[F]` in addition to `Async[F]`) but I don't know what compatibility guarantees you want to provide. I'll rework the PR as needed in any case 🙂

Cheers
~ Felix

edit: I also found cases where the execution _did_ continue on the `IO` pool even without my fix. This makes the current implementation even more wacky as the user has no deterministic control over what pool is being used. So even if we keep `futureToAsync` in its current form, we should make sure that it has deterministic and documented behavior regarding threadpools.